### PR TITLE
[build] Speed up time-to deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,9 +5,6 @@ name: Continuous Integration
       - main
       - staging
       - trying
-  pull_request:
-    branches:
-      - main
 jobs:
   node-ci:
     name: Build Gatsby Site

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,13 +1,9 @@
 name: Deploy To Branch
 'on':
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Continuous Integration
+  push:
     branches:
       - main
-    types:
-      - completed
 
 concurrency:
   group: deploy-www
@@ -15,7 +11,6 @@ jobs:
   node-ci:
     name: Deploy Gatsby Site to Branch
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,4 @@
 commit-title = "[chore] Merge in ${PR_REFS}"
 delete-merged-branches = true
-pr_status = ['Build Gatsby Site']
 status = ['Build Gatsby Site']
 update-base-for-deletes = true


### PR DESCRIPTION
Avoids having to build the site 4 times before deploying. Now only builds once to test, and once to deploy.